### PR TITLE
Add an event system to MODX, using evenement/evenement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "smarty/smarty": "^3.1",
         "james-heinrich/phpthumb": "^1.7",
         "erusev/parsedown": "^1.7",
-        "pelago/emogrifier": "^2.0"
+        "pelago/emogrifier": "^2.0",
+        "evenement/evenement": "^3.0"
     },
     "autoload": {
         "classmap": ["core/xpdo/"]

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -233,6 +233,10 @@ class modX extends xPDO {
      */
     public $smarty;
     /**
+     * @var \Evenement\EventEmitter $eventEmitter
+     */
+    public $eventEmitter;
+    /**
      * @var array $processors An array of loaded processors and their class name
      */
     public $processors = array();
@@ -453,6 +457,7 @@ class modX extends xPDO {
             $this->loadClass('modPrincipal');
             $this->loadClass('modUser');
             $this->loadClass('sources.modMediaSource');
+            $this->eventEmitter = new \Evenement\EventEmitter();
         } catch (xPDOException $xe) {
             $this->sendError('unavailable', array('error_message' => $xe->getMessage()));
         } catch (Exception $e) {
@@ -1603,6 +1608,9 @@ class modX extends xPDO {
     public function invokeEvent($eventName, array $params= array ()) {
         if (!$eventName)
             return false;
+
+        $this->eventEmitter->emit($eventName, $params);
+
         if ($this->eventMap === null && $this->context instanceof modContext)
             $this->_initEventMap($this->context->get('key'));
         if (!isset ($this->eventMap[$eventName])) {


### PR DESCRIPTION
The event system means you don't have to load a plugin in the database to listen to events, but can do it all directly from code.

See issue #2 for what this pull request is solving.

### Why did you choose evenement?

I used it for this prototype because it's simple.

I looked at a bunch of event libraries before starting coding (Zend, Symfony, PHPLeague, others) I am not tied to any particular implementation; I've used [Symfony's EventDispatcher component](https://symfony.com/doc/current/components/event_dispatcher.html) and like it, particularly [Using Event Subscribers](https://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers).

Bottom line is this is a proof of concept to see if people will accept it into MODX. At this point _what can be done using the feature_ is more important than how the feature is implemented.